### PR TITLE
Move notifications to `didActivate`-hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ module.exports = {
         }
       },
 
-      didDeploy: function(context) {
+      didActivate: function(context) {
         var preConfig  = this.readConfig('configuredServices');
         var userConfig = this.readConfig('services');
 

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -58,9 +58,9 @@ describe('notifications plugin', function() {
     assert.equal(plugin.name, 'notifications');
   });
 
-  describe('#didDeploy', function() {
-    it('implements the the `didDeploy`-hook', function() {
-      assert.ok(plugin.didDeploy);
+  describe('#didActivate', function() {
+    it('implements the `didActivate`-hook', function() {
+      assert.ok(plugin.didActivate);
     });
 
     describe('notifies services that are present as keys in the plugin config', function() {
@@ -69,7 +69,7 @@ describe('notifications plugin', function() {
           plugin.beforeHook(context);
           plugin.configure(context);
 
-          var promise = plugin.didDeploy(context);
+          var promise = plugin.didActivate(context);
 
           return assert.isFulfilled(promise)
             .then(function() {
@@ -87,7 +87,7 @@ describe('notifications plugin', function() {
           plugin.beforeHook(context);
           plugin.configure(context);
 
-          var promise = plugin.didDeploy(context);
+          var promise = plugin.didActivate(context);
 
           return assert.isFulfilled(promise)
             .then(function() {
@@ -118,7 +118,7 @@ describe('notifications plugin', function() {
         plugin.beforeHook(context);
         plugin.configure(context);
 
-        var promise = plugin.didDeploy(context);
+        var promise = plugin.didActivate(context);
 
         return assert.isFulfilled(promise)
           .then(function() {
@@ -139,7 +139,7 @@ describe('notifications plugin', function() {
         plugin.beforeHook(context);
         plugin.configure(context);
 
-        var promise = plugin.didDeploy(context);
+        var promise = plugin.didActivate(context);
 
         return assert.isRejected(promise);
       });
@@ -158,7 +158,7 @@ describe('notifications plugin', function() {
         plugin.beforeHook(context);
         plugin.configure(context);
 
-        var promise = plugin.didDeploy(context);
+        var promise = plugin.didActivate(context);
 
         return assert.isFulfilled(promise)
           .then(function() {
@@ -176,7 +176,7 @@ describe('notifications plugin', function() {
       plugin.beforeHook(context);
       plugin.configure(context);
 
-      var promise = plugin.didDeploy(context);
+      var promise = plugin.didActivate(context);
 
       return assert.isFulfilled(promise)
         .then(function() {
@@ -190,7 +190,7 @@ describe('notifications plugin', function() {
       plugin.beforeHook(context);
       plugin.configure(context);
 
-      var promise = plugin.didDeploy(context);
+      var promise = plugin.didActivate(context);
 
       return assert.isFulfilled(promise);
     });

--- a/tests/unit/lib/notify-nodetest.js
+++ b/tests/unit/lib/notify-nodetest.js
@@ -61,7 +61,7 @@ describe('Notify', function() {
       return assert.isRejected(promise);
     });
 
-    it('logs when a success was successful', function() {
+    it('logs when a request was successful', function() {
       var data = { apiKey: '12341234' };
 
       var promise = subject.send(url, data);


### PR DESCRIPTION
Sending notifications on `didDeploy` is actually a bad
idea because the simple fact that the `deploy`-pipeline
`didDeploy` does not mean that users get served a new
revision. Also rollbacks won't trigger a notification
because `didDeploy`-does not get invoked on the activation
pipeline.

Closes #4