### PR TITLE
Add http-authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,19 @@ A `service` configuration needs to provide four properties as configuration for
 - `method` The HTTP-method to use for the call (defaults to `'POST'`)
 - `headers` A property to specify custom HTTP-headers (defaults to `{}`)
 - `body` The body of the request
+- `auth` used for http-authentication
+
+`auth` should be a hash containing values:
+
+* `user` || `username`
+* `pass` || `password`
+
+Bearer authentication is also supported. Please refer to
+[request](https://github.com/request/request#http-authentication)'s docs for
+more details as `ember-cli-deploy-notifications` uses `request` internally.
 
 <hr/>
-**Whenever one of these properties returns a _falsy_ value, the service will _not_ be
+**Whenever one of these properties (except `auth`) returns a _falsy_ value, the service will _not_ be
 called.**
 <hr/>
 

--- a/lib/service.js
+++ b/lib/service.js
@@ -13,6 +13,6 @@ module.exports = CoreObject.extend({
       return typeof value === 'function' ? value.bind(this.serviceOptions)(context) : value;
     }.bind(this));
 
-    return pick(opts, ['url', 'method', 'headers', 'body']);
+    return pick(opts, ['url', 'method', 'headers', 'body', 'auth']);
   }
 });

--- a/tests/unit/lib/service-nodetest.js
+++ b/tests/unit/lib/service-nodetest.js
@@ -157,5 +157,92 @@ describe('Service', function() {
 
       assert.deepEqual(serviceCallOpts, expected);
     });
+
+    describe('http-authentication', function() {
+      it('users can pass the auth property', function() {
+        var defaults = {
+          url: 'url',
+          method: 'POST',
+          headers: {},
+          apiKey: 'api-key',
+          body: function() {
+            return {
+              apiKey: this.apiKey
+            }
+          }
+        };
+
+        var user = {
+          auth: {
+            user: 'tomster',
+            pass: 'ember'
+          }
+        };
+
+        var service = new Service({defaults: defaults, user: user});
+
+        var serviceCallOpts = service.buildServiceCall();
+
+        var expected = {
+          url: 'url',
+          method: 'POST',
+          headers: {},
+          auth: {
+            user: 'tomster',
+            pass: 'ember'
+          },
+          body: {
+            apiKey: 'api-key'
+          }
+        };
+
+        assert.deepEqual(serviceCallOpts, expected);
+      });
+
+      it('behaves like any configurable and can use a function for configuration', function() {
+        var defaults = {
+          url: 'url',
+          method: 'POST',
+          headers: {},
+          auth: function() {
+            return {
+              user: this.username,
+              pass: this.password
+            }
+          },
+          apiKey: 'api-key',
+          body: function() {
+            return {
+              apiKey: this.apiKey
+            }
+          }
+        };
+
+        var user = {
+          username: 'tomster',
+          password: 'ember'
+        };
+
+        var service = new Service({defaults: defaults, user: user});
+
+        var serviceCallOpts = service.buildServiceCall();
+
+        var expected = {
+          url: 'url',
+          method: 'POST',
+          headers: {},
+          auth: {
+            user: 'tomster',
+            pass: 'ember'
+          },
+          body: {
+            apiKey: 'api-key'
+          }
+        };
+
+        assert.deepEqual(serviceCallOpts, expected);
+
+      });
+    });
   });
 });


### PR DESCRIPTION
This makes http-authentication available to plugin users (request of course already supports it).